### PR TITLE
Check contentWindow is defined

### DIFF
--- a/fence.js
+++ b/fence.js
@@ -96,7 +96,8 @@ define(function () {
         var supportsSrcdoc = !!iframe.srcdoc;
         if (supportsSrcdoc) {
             // srcdoc is supported, add done listener (first time only)
-            if (iframe.contentWindow.document.readyState === 'complete') {
+            // if contentWindow is undefined then wait for the load event
+            if (iframe.contentWindow && iframe.contentWindow.document.readyState === 'complete') {
                 done(iframe);
             } else if (! alreadyRendered) {
                 iframe.addEventListener('load', function() {


### PR DESCRIPTION
As above, otherwise if not and not already rendered, wait for `load` to run the `done` function and do all of the fency stuff.

This is due to our iframe not always having loaded at the point of rendering so `contentWindow` is undefined and we get a LOT of Sentry errors about it ...